### PR TITLE
Prevent access rights errors in payroll preparation

### DIFF
--- a/payroll_preparation_from_timesheet/tests/common.py
+++ b/payroll_preparation_from_timesheet/tests/common.py
@@ -12,6 +12,14 @@ class PayrollPreparationCase(SavepointCase):
         super().setUpClass()
         cls.company = cls.env['res.company'].create({'name': 'Company A'})
 
+        cls.payroll_manager = cls.env['res.users'].create({
+            'name': 'payroll@manager.com',
+            'login': 'payroll@manager.com',
+            'email': 'payroll@manager.com',
+            'groups_id': [(4, cls.env.ref('payroll_preparation.group_manager').id)],
+            'company_id': cls.company.id,
+            'company_ids': [(4, cls.company.id)],
+        })
         cls.user = cls.env['res.users'].create({
             'name': 'Test User',
             'login': 'test@test.com',
@@ -43,9 +51,8 @@ class PayrollPreparationCase(SavepointCase):
 
     @classmethod
     def generate_payroll_entries(cls, period):
-        wizard = cls.env['payroll.preparation.from.timesheet'].create({
-            'period_id': period.id,
-        })
+        wizard_model = cls.env['payroll.preparation.from.timesheet'].sudo(cls.payroll_manager)
+        wizard = wizard_model.create({'period_id': period.id})
         wizard.action_validate()
 
     @classmethod

--- a/payroll_preparation_from_timesheet/tests/test_payroll_preparation_from_timesheet.py
+++ b/payroll_preparation_from_timesheet/tests/test_payroll_preparation_from_timesheet.py
@@ -1,7 +1,9 @@
 # © 2020 - today Numigi (tm) and all its contributors (https://bit.ly/numigiens)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+import pytest
 from datetime import timedelta
+from odoo.exceptions import AccessError
 from .common import PayrollPreparationCase
 
 
@@ -39,3 +41,8 @@ class TestPayrollPreparationFromTimesheet(PayrollPreparationCase):
         assert entry.company_id == self.company
         assert entry.duration == expected_duration
         assert entry.date == expected_date
+
+    def test_if_is_not_manager__access_error_raised(self):
+        self.payroll_manager.groups_id -= self.env.ref('payroll_preparation.group_manager')
+        with pytest.raises(AccessError):
+            self.generate_payroll_entries(self.period)


### PR DESCRIPTION
The payroll preparation process can use data from different applications for generate payroll entries.
When gathering this data, the payroll manager should not depend on access rights on multiple other applications
(projects, hr_contracts, etc).
Therefore, we use sudo for gathering vals to prevent tracebacks.

https://www.numigi.com/web#id=18949&action=298&model=project.task&view_type=form&menu_id=200